### PR TITLE
Add login authentication and placeholder navigation pages

### DIFF
--- a/ChazzBoutique-UI/src/App.tsx
+++ b/ChazzBoutique-UI/src/App.tsx
@@ -2,18 +2,44 @@ import { useMemo, useState } from "react";
 import AppShell from "./components/layout/AppShell";
 import { useDisableEffectsWhileResizing } from "./components/layout/useDisableEffectsWhileResizing";
 import type { MenuKey } from "./components/Sidebar";
+import { useAuth } from "./auth/AuthContext";
 import VentaPage from "./pages/VentaPage";
 import HomePage from "./pages/HomePage";
+import ProductosPage from "./pages/ProductosPage";
+import CategoriasPage from "./pages/CategoriasPage";
+import ReportesPage from "./pages/ReportesPage";
+import ProveedoresPage from "./pages/ProveedoresPage";
+import LoginPage from "./pages/LoginPage";
 
 export default function App() {
   useDisableEffectsWhileResizing();
 
+  const { user, logout } = useAuth();
   const [active, setActive] = useState<MenuKey>("venta");
 
   const content = useMemo(() => {
-    if (active === "home") return <HomePage />;
-    return <VentaPage />;
+    switch (active) {
+      case "home":
+        return <HomePage />;
+      case "productos":
+        return <ProductosPage />;
+      case "categorias":
+        return <CategoriasPage />;
+      case "reportes":
+        return <ReportesPage />;
+      case "proveedores":
+        return <ProveedoresPage />;
+      case "venta":
+      default:
+        return <VentaPage />;
+    }
   }, [active]);
 
-  return <AppShell active={active} onChange={setActive}>{content}</AppShell>;
+  if (!user) return <LoginPage />;
+
+  return (
+    <AppShell active={active} onChange={setActive} onLogout={logout}>
+      {content}
+    </AppShell>
+  );
 }

--- a/ChazzBoutique-UI/src/api/auth.ts
+++ b/ChazzBoutique-UI/src/api/auth.ts
@@ -1,0 +1,11 @@
+import { http } from "./http";
+
+export type LoginResponse = {
+  usuarioId: number;
+  nombreUsuario: string;
+  rol: string;
+};
+
+export function login(nombreUsuario: string, contrasena: string) {
+  return http.post<LoginResponse>("/api/auth/login", { nombreUsuario, contrasena });
+}

--- a/ChazzBoutique-UI/src/auth/AuthContext.tsx
+++ b/ChazzBoutique-UI/src/auth/AuthContext.tsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+import * as authApi from "../api/auth";
+
+export type AuthUser = {
+  usuarioId: number;
+  nombreUsuario: string;
+  rol: string;
+};
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  login: (nombreUsuario: string, contrasena: string) => Promise<void>;
+  logout: () => void;
+};
+
+const STORAGE_KEY = "chazz.auth";
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+function readStoredUser(): AuthUser | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed?.usuarioId === "number" &&
+      typeof parsed?.nombreUsuario === "string" &&
+      typeof parsed?.rol === "string"
+    ) {
+      return parsed as AuthUser;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(readStoredUser);
+
+  async function login(nombreUsuario: string, contrasena: string) {
+    const res = await authApi.login(nombreUsuario, contrasena);
+    const next: AuthUser = {
+      usuarioId: res.usuarioId,
+      nombreUsuario: res.nombreUsuario,
+      rol: res.rol,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    setUser(next);
+  }
+
+  function logout() {
+    localStorage.removeItem(STORAGE_KEY);
+    setUser(null);
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth debe usarse dentro de AuthProvider");
+  return ctx;
+}

--- a/ChazzBoutique-UI/src/components/Sidebar.css
+++ b/ChazzBoutique-UI/src/components/Sidebar.css
@@ -122,6 +122,9 @@
   padding: 0;
 }
 
+/* Cerrar sesión: anclado al fondo en desktop */
+.sb__logout{ margin-top: auto; }
+
 .sb__iconWrap{
   margin-left: 10px;
   width: 42px;

--- a/ChazzBoutique-UI/src/components/Sidebar.tsx
+++ b/ChazzBoutique-UI/src/components/Sidebar.tsx
@@ -2,11 +2,18 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import "./Sidebar.css";
 
-export type MenuKey = "home" | "venta";
+export type MenuKey =
+  | "home"
+  | "venta"
+  | "productos"
+  | "categorias"
+  | "reportes"
+  | "proveedores";
 
 type Props = {
   active: MenuKey;
   onChange: (k: MenuKey) => void;
+  onLogout: () => void;
 };
 
 function useMediaQuery(query: string) {
@@ -67,17 +74,74 @@ function Icon({ name, active }: { name: MenuKey; active: boolean }) {
           <path d="M3 4h2l2.4 12.2a2 2 0 0 0 2 1.6h7.9a2 2 0 0 0 2-1.6L22 8H6.2" />
         </svg>
       );
+    case "productos":
+      return (
+        <svg {...common}>
+          <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+          <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+          <line x1="12" y1="22.08" x2="12" y2="12" />
+        </svg>
+      );
+    case "categorias":
+      return (
+        <svg {...common}>
+          <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+          <line x1="7" y1="7" x2="7.01" y2="7" />
+        </svg>
+      );
+    case "reportes":
+      return (
+        <svg {...common}>
+          <line x1="18" y1="20" x2="18" y2="10" />
+          <line x1="12" y1="20" x2="12" y2="4" />
+          <line x1="6" y1="20" x2="6" y2="14" />
+        </svg>
+      );
+    case "proveedores":
+      return (
+        <svg {...common}>
+          <rect x="1" y="3" width="15" height="13" />
+          <polygon points="16 8 20 8 23 11 23 16 16 16 16 8" />
+          <circle cx="5.5" cy="18.5" r="2.5" />
+          <circle cx="18.5" cy="18.5" r="2.5" />
+        </svg>
+      );
     default:
       return null;
   }
 }
 
+function LogoutIcon() {
+  return (
+    <svg
+      width={18}
+      height={18}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="sb__icon"
+      aria-hidden="true"
+    >
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  );
+}
+
 const items: { key: MenuKey; label: string }[] = [
   { key: "venta", label: "Venta" },
   { key: "home", label: "Catálogo" },
+  { key: "productos", label: "Productos" },
+  { key: "categorias", label: "Categorías" },
+  { key: "reportes", label: "Reportes" },
+  { key: "proveedores", label: "Proveedores" },
 ];
 
-export default function Sidebar({ active, onChange }: Props) {
+export default function Sidebar({ active, onChange, onLogout }: Props) {
   const isMobile = useMediaQuery("(max-width: 900px)");
 
   // Desktop hover open
@@ -207,6 +271,23 @@ export default function Sidebar({ active, onChange }: Props) {
               </button>
             );
           })}
+
+          <button
+            type="button"
+            title="Cerrar sesión"
+            onClick={onLogout}
+            className="sb__item sb__logout"
+          >
+            <span className="sb__iconWrap" aria-hidden="true">
+              <LogoutIcon />
+            </span>
+
+            {!isMobile && (
+              <span className={`sb__labelSlot ${expanded ? "is-open" : "is-closed"}`}>
+                <span className="sb__label">Cerrar sesión</span>
+              </span>
+            )}
+          </button>
         </nav>
       </motion.aside>
     </>

--- a/ChazzBoutique-UI/src/components/layout/AppShell.tsx
+++ b/ChazzBoutique-UI/src/components/layout/AppShell.tsx
@@ -4,13 +4,14 @@ import Sidebar, { type MenuKey } from "../Sidebar";
 type AppShellProps = {
   active: MenuKey;
   onChange: (key: MenuKey) => void;
+  onLogout: () => void;
   children: ReactNode;
 };
 
-export default function AppShell({ active, onChange, children }: AppShellProps) {
+export default function AppShell({ active, onChange, onLogout, children }: AppShellProps) {
   return (
     <div className="app-shell">
-      <Sidebar active={active} onChange={onChange} />
+      <Sidebar active={active} onChange={onChange} onLogout={onLogout} />
       <main className="app-content">{children}</main>
     </div>
   );

--- a/ChazzBoutique-UI/src/features/venta/useVenta.ts
+++ b/ChazzBoutique-UI/src/features/venta/useVenta.ts
@@ -3,14 +3,15 @@ import * as posApi from "../../api/pos";
 import type { CrearVentaRequest, ProductoLite, VarianteLookup, VarianteRow } from "../../api/pos";
 import type { VentaOk, VentaRow, VentaToast } from "./types";
 import { dropRecordKey, money, onlyDigits, parseIntSafe } from "./utils";
-
-const USUARIO_ID = 1;
+import { useAuth } from "../../auth/AuthContext";
 
 function getNombreVariante(v: VarianteLookup | null, fallback = ""): string {
   return v?.nombreProducto ?? fallback;
 }
 
 export function useVenta() {
+  const { user } = useAuth();
+
   const [modoNombre, setModoNombre] = useState(false);
 
   const [codigo, setCodigo] = useState("");
@@ -249,6 +250,11 @@ export function useVenta() {
   async function onPagar() {
     if (rows.length === 0) return;
 
+    if (!user) {
+      showToast("error", "Sesión no válida. Inicia sesión de nuevo.");
+      return;
+    }
+
     if (montoPago < total) {
       showToast("error", `Pago insuficiente. Falta: ${money(total - montoPago)}`);
       return;
@@ -257,7 +263,7 @@ export function useVenta() {
     setLoadingPay(true);
     try {
       const payload: CrearVentaRequest = {
-        usuarioId: USUARIO_ID,
+        usuarioId: user.usuarioId,
         descuento,
         montoPago,
         detalles: rows.map((r) => ({ codigoBarras: r.codigoBarras, cantidad: r.cantidad })),

--- a/ChazzBoutique-UI/src/main.tsx
+++ b/ChazzBoutique-UI/src/main.tsx
@@ -1,11 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { AuthProvider } from "./auth/AuthContext";
 import "./styles/tokens.css";
 import "./styles/app.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>
 );

--- a/ChazzBoutique-UI/src/pages/CategoriasPage.tsx
+++ b/ChazzBoutique-UI/src/pages/CategoriasPage.tsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from "./PlaceholderPage";
+
+export default function CategoriasPage() {
+  return <PlaceholderPage title="Categorías" />;
+}

--- a/ChazzBoutique-UI/src/pages/LoginPage.tsx
+++ b/ChazzBoutique-UI/src/pages/LoginPage.tsx
@@ -1,0 +1,73 @@
+import { useState, type FormEvent } from "react";
+import "../styles/login.css";
+import { useAuth } from "../auth/AuthContext";
+
+export default function LoginPage() {
+  const { login } = useAuth();
+
+  const [nombreUsuario, setNombreUsuario] = useState("");
+  const [contrasena, setContrasena] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const puedeEnviar = nombreUsuario.trim().length > 0 && contrasena.length > 0;
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!puedeEnviar || loading) return;
+
+    setError(null);
+    setLoading(true);
+    try {
+      await login(nombreUsuario.trim(), contrasena);
+    } catch (err) {
+      setError((err as Error).message || "No se pudo iniciar sesión");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="login">
+      <form className="login__card" onSubmit={onSubmit}>
+        <img
+          className="login__logo"
+          src="/images/chazzLogoBlack.png"
+          alt="Chazz Boutique"
+          draggable={false}
+        />
+
+        <h1 className="login__title">Iniciar sesión</h1>
+
+        <label className="login__field">
+          <span className="login__label">Usuario</span>
+          <input
+            className="login__input"
+            type="text"
+            value={nombreUsuario}
+            onChange={(e) => setNombreUsuario(e.target.value)}
+            autoComplete="username"
+            autoFocus
+          />
+        </label>
+
+        <label className="login__field">
+          <span className="login__label">Contraseña</span>
+          <input
+            className="login__input"
+            type="password"
+            value={contrasena}
+            onChange={(e) => setContrasena(e.target.value)}
+            autoComplete="current-password"
+          />
+        </label>
+
+        {error && <p className="login__error">{error}</p>}
+
+        <button className="login__submit" type="submit" disabled={!puedeEnviar || loading}>
+          {loading ? "Entrando…" : "Entrar"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/ChazzBoutique-UI/src/pages/PlaceholderPage.tsx
+++ b/ChazzBoutique-UI/src/pages/PlaceholderPage.tsx
@@ -1,0 +1,12 @@
+type PlaceholderPageProps = {
+  title: string;
+};
+
+export default function PlaceholderPage({ title }: PlaceholderPageProps) {
+  return (
+    <section className="page-placeholder">
+      <h1 className="page-placeholder__title">{title}</h1>
+      <p className="page-placeholder__hint">Pendiente de implementación</p>
+    </section>
+  );
+}

--- a/ChazzBoutique-UI/src/pages/ProductosPage.tsx
+++ b/ChazzBoutique-UI/src/pages/ProductosPage.tsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from "./PlaceholderPage";
+
+export default function ProductosPage() {
+  return <PlaceholderPage title="Productos" />;
+}

--- a/ChazzBoutique-UI/src/pages/ProveedoresPage.tsx
+++ b/ChazzBoutique-UI/src/pages/ProveedoresPage.tsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from "./PlaceholderPage";
+
+export default function ProveedoresPage() {
+  return <PlaceholderPage title="Proveedores" />;
+}

--- a/ChazzBoutique-UI/src/pages/ReportesPage.tsx
+++ b/ChazzBoutique-UI/src/pages/ReportesPage.tsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from "./PlaceholderPage";
+
+export default function ReportesPage() {
+  return <PlaceholderPage title="Reportes" />;
+}

--- a/ChazzBoutique-UI/src/styles/app.css
+++ b/ChazzBoutique-UI/src/styles/app.css
@@ -45,6 +45,19 @@ body{
   box-shadow: var(--shadow);
 }
 
+.page-placeholder__title{
+  margin: 0 0 8px;
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--text);
+}
+
+.page-placeholder__hint{
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
 html.is-resizing *,
 html.is-resizing *::before,
 html.is-resizing *::after{

--- a/ChazzBoutique-UI/src/styles/login.css
+++ b/ChazzBoutique-UI/src/styles/login.css
@@ -1,0 +1,97 @@
+/* Login gate */
+.login{
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--bg);
+}
+
+.login__card{
+  width: 100%;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-2);
+  padding: 32px 28px;
+}
+
+.login__logo{
+  height: 64px;
+  width: auto;
+  max-width: 180px;
+  object-fit: contain;
+  align-self: center;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.login__title{
+  margin: 0;
+  text-align: center;
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -.02em;
+  color: var(--text);
+}
+
+.login__field{
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.login__label{
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.login__input{
+  height: 44px;
+  padding: 0 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--text);
+  font-size: 15px;
+  outline: none;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.login__input:focus{
+  border-color: var(--focus);
+  box-shadow: 0 0 0 4px var(--focusRing);
+}
+
+.login__error{
+  margin: 0;
+  color: var(--brand);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.login__submit{
+  height: 46px;
+  margin-top: 4px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--brand);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 14px 30px rgba(176,50,53,.22);
+  transition: filter 160ms ease, transform 120ms ease;
+}
+
+.login__submit:hover{ filter: brightness(1.03); }
+.login__submit:active{ transform: translateY(1px); }
+.login__submit:disabled{ opacity: .55; cursor: not-allowed; transform: none; }

--- a/ChazzBoutiqueApi/src/main/java/com/juvenr/mqc/chazzboutiqueapi/auth/AuthController.java
+++ b/ChazzBoutiqueApi/src/main/java/com/juvenr/mqc/chazzboutiqueapi/auth/AuthController.java
@@ -1,0 +1,43 @@
+package com.juvenr.mqc.chazzboutiqueapi.auth;
+
+import com.juvenr.mqc.chazzboutiqueapi.auth.dto.LoginRequest;
+import com.juvenr.mqc.chazzboutiqueapi.auth.dto.LoginResponse;
+import com.mycompany.chazzboutiquenegocio.dtos.InicioSesionDTO;
+import com.mycompany.chazzboutiquenegocio.dtos.UsuarioDTO;
+import com.mycompany.chazzboutiquenegocio.excepciones.NegocioException;
+import com.mycompany.chazzboutiquenegocio.interfacesObjetosNegocio.IUsuarioNegocio;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final IUsuarioNegocio usuarioNegocio;
+
+    public AuthController(IUsuarioNegocio usuarioNegocio) {
+        this.usuarioNegocio = usuarioNegocio;
+    }
+
+    @PostMapping("/login")
+    public LoginResponse login(@RequestBody LoginRequest req) {
+        UsuarioDTO usuario;
+        try {
+            usuario = usuarioNegocio.iniciarSesion(
+                    new InicioSesionDTO(req.getNombreUsuario(), req.getContrasena())
+            );
+        } catch (NegocioException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Usuario o contraseña incorrectos");
+        }
+
+        if (usuario.getActivo() == null || !usuario.getActivo()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Usuario inactivo");
+        }
+
+        return new LoginResponse(usuario.getId(), usuario.getNombreUsuario(), usuario.getRol());
+    }
+}

--- a/ChazzBoutiqueApi/src/main/java/com/juvenr/mqc/chazzboutiqueapi/auth/dto/LoginRequest.java
+++ b/ChazzBoutiqueApi/src/main/java/com/juvenr/mqc/chazzboutiqueapi/auth/dto/LoginRequest.java
@@ -1,0 +1,31 @@
+package com.juvenr.mqc.chazzboutiqueapi.auth.dto;
+
+public class LoginRequest {
+
+    private String nombreUsuario;
+    private String contrasena;
+
+    public LoginRequest() {
+    }
+
+    public LoginRequest(String nombreUsuario, String contrasena) {
+        this.nombreUsuario = nombreUsuario;
+        this.contrasena = contrasena;
+    }
+
+    public String getNombreUsuario() {
+        return nombreUsuario;
+    }
+
+    public void setNombreUsuario(String nombreUsuario) {
+        this.nombreUsuario = nombreUsuario;
+    }
+
+    public String getContrasena() {
+        return contrasena;
+    }
+
+    public void setContrasena(String contrasena) {
+        this.contrasena = contrasena;
+    }
+}

--- a/ChazzBoutiqueApi/src/main/java/com/juvenr/mqc/chazzboutiqueapi/auth/dto/LoginResponse.java
+++ b/ChazzBoutiqueApi/src/main/java/com/juvenr/mqc/chazzboutiqueapi/auth/dto/LoginResponse.java
@@ -1,0 +1,41 @@
+package com.juvenr.mqc.chazzboutiqueapi.auth.dto;
+
+public class LoginResponse {
+
+    private Long usuarioId;
+    private String nombreUsuario;
+    private String rol;
+
+    public LoginResponse() {
+    }
+
+    public LoginResponse(Long usuarioId, String nombreUsuario, String rol) {
+        this.usuarioId = usuarioId;
+        this.nombreUsuario = nombreUsuario;
+        this.rol = rol;
+    }
+
+    public Long getUsuarioId() {
+        return usuarioId;
+    }
+
+    public void setUsuarioId(Long usuarioId) {
+        this.usuarioId = usuarioId;
+    }
+
+    public String getNombreUsuario() {
+        return nombreUsuario;
+    }
+
+    public void setNombreUsuario(String nombreUsuario) {
+        this.nombreUsuario = nombreUsuario;
+    }
+
+    public String getRol() {
+        return rol;
+    }
+
+    public void setRol(String rol) {
+        this.rol = rol;
+    }
+}

--- a/ChazzBoutiqueApi/src/main/java/com/juvenr/mqc/chazzboutiqueapi/config/NegocioBeansConfig.java
+++ b/ChazzBoutiqueApi/src/main/java/com/juvenr/mqc/chazzboutiqueapi/config/NegocioBeansConfig.java
@@ -2,10 +2,12 @@ package com.juvenr.mqc.chazzboutiqueapi.config;
 
 import com.mycompany.chazzboutiquenegocio.interfacesObjetosNegocio.ICategoriaNegocio;
 import com.mycompany.chazzboutiquenegocio.interfacesObjetosNegocio.IProductoNegocio;
+import com.mycompany.chazzboutiquenegocio.interfacesObjetosNegocio.IUsuarioNegocio;
 import com.mycompany.chazzboutiquenegocio.interfacesObjetosNegocio.IVarianteProductoNegocio;
 import com.mycompany.chazzboutiquenegocio.interfacesObjetosNegocio.IVentaNegocio;
 import com.mycompany.chazzboutiquenegocio.objetosNegocio.CategoriaNegocio;
 import com.mycompany.chazzboutiquenegocio.objetosNegocio.ProductoNegocio;
+import com.mycompany.chazzboutiquenegocio.objetosNegocio.UsuarioNegocio;
 import com.mycompany.chazzboutiquenegocio.objetosNegocio.VarianteProductoNegocio;
 import com.mycompany.chazzboutiquenegocio.objetosNegocio.VentaNegocio;
 import com.mycompany.chazzboutiquepersistencia.conexion.ConexionBD;
@@ -96,6 +98,11 @@ public class NegocioBeansConfig {
     @Bean
     public ICategoriaNegocio categoriaNegocio(ICategoriaDAO categoriaDAO) {
         return new CategoriaNegocio(categoriaDAO);
+    }
+
+    @Bean
+    public IUsuarioNegocio usuarioNegocio(IUsuarioDAO usuarioDAO) {
+        return new UsuarioNegocio(usuarioDAO);
     }
 
 }


### PR DESCRIPTION
Backend:
- AuthController POST /api/auth/login reusing UsuarioNegocio; 401 on bad credentials, 403 on inactive user, password never returned
- LoginRequest/LoginResponse DTOs and IUsuarioNegocio bean wiring

Frontend:
- AuthProvider/useAuth with localStorage session and a LoginPage gate
- Replace hardcoded USUARIO_ID with the authenticated user's id in venta
- Sidebar placeholder sections (Productos, Categorias, Reportes, Proveedores) plus a logout button